### PR TITLE
Update seyren

### DIFF
--- a/seyren
+++ b/seyren
@@ -25,7 +25,7 @@ export SMTP_PORT
 SEYREN_URL="http://$hostname:8080/seyren"
 export SEYREN_URL
 
-PIDGET=$(ps -ef | grep java | grep -v grep | awk '{print $2}')
+PIDGET=$(ps -ef | grep seyren | grep -v grep | awk '{print $2}')
 
 # Seyren Daemon - Enter your Java location and seyren-master install directories - Amend the log directory if needed
 


### PR DESCRIPTION
PIDGET=$(ps -ef | grep seyren | grep -v grep | awk '{print $2}') was automatically killing other processes (such as elasticsearch and logstash) but changing this to grep for seyren only kills the seyren process.