### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this you will need to make the below amendments for your environment
 ##Instructions
 
 1. Copy the seyren init.d script to /etc/init.d/ of the server that its installed on.
-2. Amend the permissions of the seyren script so that its runnable (eg chmod 777 seyren)
+2. Amend the permissions of the seyren script so that its runnable (eg chmod 754 seyren)
 3. Amend the Core environment parameters in the init.d script for your environment detailed below.
 4. Amend the seyrend java directory and home directory for the seyren install. (EG /usr/bin/java and /usr/local/seyren-master)
 


### PR DESCRIPTION
A group member and/or non-root user shouldn't be able to write to the init script. Additionally, it should restrict who can bounce the service. If the service was supposed to be bounced by many users, they should share the group of the init script.
